### PR TITLE
Avoid panic when given an empty program

### DIFF
--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -39,6 +39,12 @@ pub fn evaluate(code_lines: Vec<lexer::LineOfCode>) -> Result<String, String> {
     let mut line_has_goto = false;
 
     loop {
+
+        // If we're at the end of the program then we stop
+        if line_index == num_lines {
+               break;
+        }
+
         let line_number = line_numbers[line_index];
         let tokens = &lineno_to_code[line_number];
         let mut token_iter = tokens.iter().peekable();


### PR DESCRIPTION
This pull-request tests that we're not at the end of the program before proceeding with the main loop, which has the effect of avoiding a panic when given an empty input-program.

This closes #1.